### PR TITLE
usrcheat: fix incorrect toxml mode behavior

### DIFF
--- a/usrcheat.c
+++ b/usrcheat.c
@@ -858,7 +858,7 @@ int main(int argc, char** argv) {
 	if(mode == -1) return usage(argv[0]);
 	fnin = argv[2];
 	fnout = argv[3];
-	if(mode > 1) {
+	if(mode >= 1) {
 		if(!cheatdb_read(&db, fnin, &error)) {
 		e:
 			fprintf(stderr, "error! %s\n", error);


### PR DESCRIPTION
The toxml mode sets mode to 1, but it reads the input in xml format instead of dat format because it reads dat format if mode is > 1 (and 1 is not greater than 1).